### PR TITLE
Google Fonts added

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
     <!-- The above 4 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+	<link href="https://fonts.googleapis.com/css?family=Josefin+Sans|Playfair+Display:400,700,900" rel="stylesheet">
 
     <meta name="description" content="A Doctor Who Fan Page by a Whovian Girl."/>
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
     <!-- The above 4 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-	<link href="https://fonts.googleapis.com/css?family=Josefin+Sans|Playfair+Display:400,700,900" rel="stylesheet">
 
     <meta name="description" content="A Doctor Who Fan Page by a Whovian Girl."/>
 
@@ -25,6 +24,7 @@
     <!--Need to get the following fonts from Google Fonts: Playfair Display: 400, 700, 900 and Josefin Sans-->
 
     <!--Font Link 1-->
+    <link href="https://fonts.googleapis.com/css?family=Josefin+Sans|Playfair+Display:400,700,900" rel="stylesheet">
     <!--Font Link 2-->
 
 </head><!--End Head Tags-->


### PR DESCRIPTION
Added fonts from Google Fonts: #1 
🤠 
Playfair Display: 400, 700, 900
Josefin Sans.

